### PR TITLE
Fix by using nightly

### DIFF
--- a/container-image/install-tools.sh
+++ b/container-image/install-tools.sh
@@ -16,6 +16,11 @@ apt-get update
 apt-get install -y azure-cli
 rm -rf /var/lib/apt/lists/*
 
+curl -sLo tofu.zip https://nightlies.opentofu.org/nightlies/20250909/tofu_nightly-20250909-22910f2b01_linux_amd64.zip
+unzip tofu.zip
+mkdir /tmp/ott
+mv tofu /tmp/ott
+
 curl -fsSL https://get.opentofu.org/opentofu.gpg > /etc/apt/trusted.gpg.d/opentofu.gpg
 curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | gpg --no-tty --batch --dearmor -o /etc/apt/trusted.gpg.d/opentofu-repo.gpg
 chmod a+r /etc/apt/trusted.gpg.d/opentofu.gpg /etc/apt/trusted.gpg.d/opentofu-repo.gpg

--- a/container-image/tf-demo/deploy.sh
+++ b/container-image/tf-demo/deploy.sh
@@ -5,8 +5,8 @@ az login --identity
 
 SUBSCRIPTION_ID=$(az account show --query "id" -o tsv)
 
-tofu init
-tofu plan \
+/tmp/ott/tofu init
+/tmp/ott/tofu plan \
     -var "azure_subscription_id=$SUBSCRIPTION_ID" \
     -var "backend_resource_group_name=$BACKEND_RESOURCE_GROUP_NAME" \
     -var "backend_storage_account_name=$BACKEND_STORAGE_ACCOUNT_NAME" \


### PR DESCRIPTION
Note that the error described in [this issue](https://github.com/opentofu/opentofu/issues/3010) is no longer present after using the nightly, which uses the newly-rewritten `azurerm` backend.